### PR TITLE
Fix error on Special:Version

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -296,7 +296,6 @@
 			"value": null
 		}
 	},
-	"ForeignResourcesDir": "resources/lib",
 	"ResourceFileModulePaths": {
 		"localBasePath": "resources",
 		"remoteExtPath": "TimedMediaHandler/resources"


### PR DESCRIPTION
https://github.com/weirdgloop/mediawiki-extensions-TimedMediaHandler/commit/f24df569bc0876520415ef582b37f0541e4e1bb4 introduced the `ForeignResourcesDir` directive into the extension manifest in order to display versions of `video.js` and `ogv.js` on Special:Version. Since both of these are removed in this fork, Special:Version errors out due to `resources/lib/foreign-resources.yaml` not existing.

Weird Gloop production wikis don't appear to be using this branch, so the error doesn't manifest there yet.